### PR TITLE
fixed: spelling mistake

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ In a nutshell, it's the concept of extracting value (profit) by making certain t
 Typically, MEV happens when a certain transaction must be included in a certain block (usually the current block) to actually be profitable. Additionally, it sometimes may also need to be in a specific place in the block - for example buying a highly contested NFT drop right after the contract gets deployed, within the same block the contract was deployed, unlike us normies who wait at least until the next block so Metamask recognizes the contract as having been deployed before it sends a transaction out by which time gas price may have gone up significantly.
 
 ## MEV Extraction
-In theory, MEV could only be extracted by miners, and this was true in the early days. With miners having control over block production, they could guarauntee for themselves the execution of a profitable transaction, and just not include the transaction in the block if it didn't turn out to be profitable. Today, however, a large portion of MEV is extracted by independent network participants referred to as `Searchers`. We will learn more about exactly what they do, but in a nutshell they run complex algorithms to find opportunities for profiting on chain and have bots to automatically submit those transactions to the network.
+In theory, MEV could only be extracted by miners, and this was true in the early days. With miners having control over block production, they could guarantee for themselves the execution of a profitable transaction, and just not include the transaction in the block if it didn't turn out to be profitable. Today, however, a large portion of MEV is extracted by independent network participants referred to as `Searchers`. We will learn more about exactly what they do, but in a nutshell they run complex algorithms to find opportunities for profiting on chain and have bots to automatically submit those transactions to the network.
 
 Miners still continue to get a portion of the MEV profit made by searchers, as searchers generally tend to pay very high gas fees to try and ensure their transaction is included in the block. We'll look at some example cases shortly.
 
@@ -27,7 +27,7 @@ This had led to the rise of research in the field of **Gas Golfing** - a fancy w
 
 <Quiz questionId="99e3fc3d-d650-4663-9afb-8780f80e4e6d" />
 
-`Searchers` use the concept of Gas Golfing to be able to program transactions in such a way that they use the least amount of gas. This is because of the formulae `gas fees = gas price * gas used`. So if you decrease your `gas used`, you can increase your `gas price` to arrive at the same `gas fees`. This helps in competitive MEV opportunities as by being able to pay higher gas fees than your competitors means that your chances of getting your transaction included are higher.
+`Searchers` use the concept of Gas Golfing to be able to program transactions in such a way that they use the least amount of gas. This is because of the formula `gas fees = gas price * gas used`. So if you decrease your `gas used`, you can increase your `gas price` to arrive at the same `gas fees`. This helps in competitive MEV opportunities as by being able to pay higher gas fees than your competitors means that your chances of getting your transaction included are higher.
 
 <Quiz questionId="0fa2eec9-9bf3-45a5-84c8-0a911ed4ca23" />
 


### PR DESCRIPTION
spelling error found on **MEV-Theory**

changed to:

> ``` guarauntee => guarantee ```
> ``` formulae => formula ```
